### PR TITLE
fix: use mweb instead of *_creator player client when using oauth

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For general plugin support, please see the yt-dlp discord server as responses ma
 
 ## Installation
 
-Requires yt-dlp `2024.08.XX` or above.
+**Requires yt-dlp `2024.8.13.232739 (nightly)` or above.**
 
 If yt-dlp is installed through `pip` or `pipx`, you can install the plugin with the following:
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For general plugin support, please see the yt-dlp discord server as responses ma
 
 ## Installation
 
-Requires yt-dlp `2023.10.13` or above.
+Requires yt-dlp `2024.08.XX` or above.
 
 If yt-dlp is installed through `pip` or `pipx`, you can install the plugin with the following:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = yt-dlp-youtube-oauth2
-version = 2023.12.30
+version = 2024.08.17
 
 [options]
 packages = find_namespace:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = yt-dlp-youtube-oauth2
-version = 2024.08.17
+version = 2024.08.31
 
 [options]
 packages = find_namespace:

--- a/yt_dlp_plugins/extractor/youtubeoauth.py
+++ b/yt_dlp_plugins/extractor/youtubeoauth.py
@@ -12,7 +12,7 @@ from yt_dlp.extractor.youtube import YoutubeBaseInfoExtractor
 import importlib
 import inspect
 
-_EXCLUDED_IES = ('YoutubeBaseInfoExtractor', 'YoutubeConsentRedirectIE', 'YoutubeFavouritesIE', 'YoutubeTabBaseInfoExtractor')
+_EXCLUDED_IES = ('YoutubeBaseInfoExtractor', 'YoutubeTabBaseInfoExtractor')
 
 YOUTUBE_IES = filter(
     lambda member: issubclass(member[1], YoutubeBaseInfoExtractor) and member[0] not in _EXCLUDED_IES,

--- a/yt_dlp_plugins/extractor/youtubeoauth.py
+++ b/yt_dlp_plugins/extractor/youtubeoauth.py
@@ -12,8 +12,10 @@ from yt_dlp.extractor.youtube import YoutubeBaseInfoExtractor
 import importlib
 import inspect
 
+_EXCLUDED_IES = ('YoutubeBaseInfoExtractor', 'YoutubeConsentRedirectIE', 'YoutubeFavouritesIE', 'YoutubeTabBaseInfoExtractor')
+
 YOUTUBE_IES = filter(
-    lambda member: issubclass(member[1], YoutubeBaseInfoExtractor),
+    lambda member: issubclass(member[1], YoutubeBaseInfoExtractor) and member[0] not in _EXCLUDED_IES,
     inspect.getmembers(importlib.import_module('yt_dlp.extractor.youtube'), inspect.isclass)
 )
 
@@ -157,10 +159,18 @@ for _, ie in YOUTUBE_IES:
         _NETRC_MACHINE = 'youtube'
         _use_oauth2 = False
 
+        # Remove any default *_creator clients as they do not support oauth
+        _OAUTH2_UNSUPPORTED_CLIENTS = ('web_creator', 'android_creator', 'ios_creator')
+        # Additional clients to add when using oauth
+        _OAUTH2_CLIENTS = ('mweb', )
+
         def _perform_login(self, username, password):
             if username == 'oauth2':
                 self._use_oauth2 = True
                 self.initialize_oauth()
+                self._DEFAULT_CLIENTS = tuple(
+                    c for c in getattr(self, '_DEFAULT_CLIENTS', []) if c not in self._OAUTH2_UNSUPPORTED_CLIENTS
+                ) + self._OAUTH2_CLIENTS
 
         def _create_request(self, *args, **kwargs):
             request = super()._create_request(*args, **kwargs)


### PR DESCRIPTION
fixes https://github.com/coletdjnz/yt-dlp-youtube-oauth2/issues/20
fixes https://github.com/coletdjnz/yt-dlp-youtube-oauth2/issues/18